### PR TITLE
Replace tick instead of cloning it in update + some tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ spin_sleep = "1.1.1"
 [dev-dependencies]
 winit = "0.27.5"
 simplelog = "0.12.0"
+
+[lib]
+doctest = false

--- a/src/tick.rs
+++ b/src/tick.rs
@@ -4,7 +4,7 @@ use crate::{error::SaunterError, math::MathError};
 use std::{
     error::Error,
     fmt::{self, Debug, Display, Formatter},
-    time::Instant,
+    time::Instant, mem,
 };
 
 // A snapshot of the state of the game engine, or current scene at the time of creation.
@@ -45,8 +45,7 @@ impl<T: Tick> Ticks<T> {
 
     /// Drops last tick and replaces it with new tick, and then replaces new tick with the new new tick.
     pub fn update(&mut self, new_tick: T) {
-        self.last_tick = Some(self.new_tick.clone());
-        self.new_tick = new_tick;
+        self.last_tick = Some(mem::replace(&mut self.new_tick, new_tick));
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,41 @@
+use std::time::Instant;
+use saunter::{math::MathError, tick::{Ticks, Tick}};
+
+#[derive(Copy, Clone, Debug)]
+struct TestTick {
+    tick: u8,
+}
+
+impl Tick for TestTick {
+    fn lerp(&self, _b: &Self, _t: f32) -> Result<Self, MathError> {
+        unimplemented!()
+    }
+
+    fn get_time(&self) -> &Instant {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn test_ticks_update() {
+    let mut ticks = Ticks {
+        last_tick: None,
+        new_tick: TestTick { tick: 0 },
+    };
+
+    assert!(ticks.last_tick.is_none());
+    assert_eq!(ticks.new_tick.tick, 0);
+
+    ticks.update(TestTick { tick: 1 });
+    assert!(ticks.last_tick.is_some());
+    assert_eq!(ticks.last_tick.unwrap().tick, 0);
+    assert_eq!(ticks.new_tick.tick, 1);
+
+    ticks.update(TestTick { tick: 2 });
+    assert_eq!(ticks.last_tick.unwrap().tick, 1);
+    assert_eq!(ticks.new_tick.tick, 2);
+
+    ticks.update(TestTick { tick: 3 });
+    assert_eq!(ticks.last_tick.unwrap().tick, 2);
+    assert_eq!(ticks.new_tick.tick, 3);
+}


### PR DESCRIPTION
I worry that as state in ticks grows they'll become more expensive to clone. We could optimize it by replacing the memory directly. I also added some tests, and disabled the doc tests as they don't seem to be functional.